### PR TITLE
olimex-msp430-arduino-uno: fix statement on copyright

### DIFF
--- a/olimex-msp430-arduino-uno/COPYRIGHT.md
+++ b/olimex-msp430-arduino-uno/COPYRIGHT.md
@@ -14,6 +14,7 @@ Library Files
 | File                                                                  | License (SPDX)    | Copyright Owner                           | Link                                                                              | Comment                                                   |
 |:--------------------------------------------------------------------- |:----------------- |:----------------------------------------- |:--------------------------------------------------------------------------------- |:--------------------------------------------------------- |
 | `custom_lib.pretty/Arduino_Uno_R3_Shield.kicad_mod`                   | CC-BY-SA-4.0      | https://github.com/Alarm-Siren            | https://github.com/Alarm-Siren/arduino-kicad-library                              | Minor Modifications from Upstream                         |
+| `custom_lib.pretty/RIOT-Logo.kicad_mod`                               | ?                 | https://github.com/RIOT-OS                | https://github.com/RIOT-OS                                                        | Official RIOT Logo                                        |
 
 Library Symbols (in `lib.kicad_sym`)
 ------------------------------------


### PR DESCRIPTION
The official RIOT logo is one of the exceptions in the adapter board that I have no copyright of, but I forgot to add it to the list of exceptions. This adds the missing entry.